### PR TITLE
ctx helyett db

### DIFF
--- a/docs/gyakorlat/ef/index.md
+++ b/docs/gyakorlat/ef/index.md
@@ -111,7 +111,7 @@ Debugger segítségével nézd meg, hogy milyen SQL utasítás generálódik: az
                             where p.Stock > 30
                             select p;
         // alternatív szintaktika
-        // var qProductStock = ctx.Product.Where(p => p.Stock > 30);
+        // var qProductStock = db.Product.Where(p => p.Stock > 30);
 
         foreach (var p in qProductStock)
             Console.WriteLine("\t\tName={0}\tStock={1}", p.Name, p.Stock);
@@ -122,7 +122,7 @@ Debugger segítségével nézd meg, hogy milyen SQL utasítás generálódik: az
                             where p.OrderItems.Count >= 2
                             select p;
         // alternatív szintaktika
-        // var qProductOrder = ctx.Product.Where(p => p.OrderItem.Count >= 2);
+        // var qProductOrder = db.Product.Where(p => p.OrderItem.Count >= 2);
 
         foreach (var p in qProductOrder)
             Console.WriteLine("\t\tName={0}", p.Name);
@@ -168,7 +168,7 @@ Debugger segítségével nézd meg, hogy milyen SQL utasítás generálódik: az
                         where p.Price == db.Product.Max(a => a.Price)
                         select p;
         // alternatív szintaktika
-        // var qPriceMax = ctx.Product.Where(p => p.Price == ctx.Product.Max(p2 => p2.Price));
+        // var qPriceMax = db.Product.Where(p => p.Price == db.Product.Max(p2 => p2.Price));
         foreach (var t in qPriceMax)
             Console.WriteLine("\t\tName={0}\tPrice={1}", t.Name, t.Price);
 


### PR DESCRIPTION
Kisebb elírás miatt ctx szerepelt db helyett. Azért kell db, mivel így volt deklarálva.