### PR TITLE
Elírás az ADO.NET jegyzetben

### DIFF
--- a/docs/jegyzet/adonet/index.md
+++ b/docs/jegyzet/adonet/index.md
@@ -306,7 +306,7 @@ using(var conn = new SqlConnection(connectionString))
 
 - ütközések lehetnek a visszamentés során
 - a `DataSet` adatai nem mindig a legfrissebbek
-- memóriát foglal - szerver oldalon nem ezért nem is használjuk
+- memóriát foglal - szerver oldalon ezért is nem használjuk
 
 ## Veszélyforrások
 


### PR DESCRIPTION
Ado.NET jegyzetben a "nem ezért nem is" kicserélve "ezért is nem"-re