### PR TITLE
Product.Price double to decimal type in EF homework

### DIFF
--- a/docs/hazi/ef/index.md
+++ b/docs/hazi/ef/index.md
@@ -30,7 +30,7 @@ Készítsd el az adatbázisunk (egy részének) Entity Framework leképzését _
             [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
             public int ID { get; set; }
             public string Name { get; set; }
-            public double Price { get; set; }
+            public decimal Price { get; set; }
             public int Stock { get; set; }
         }
     }


### PR DESCRIPTION
A példakódban a Price típusa `double`, viszont az adatbázisban decimal. [Dokumentáció alapján](https://learn.microsoft.com/en-us/dotnet/framework/data/adonet/sql-server-data-type-mappings) a kódban a `decimal` típust kellene használni, különben errort kapunk arra, hogy nem lehetséges az automatikus `Decimal` -> `Double` castolás