### PR TITLE
Entity Framework 3.2-es feladat megoldásában typo javítás

### DIFF
--- a/docs/hu/seminar/ef/index.md
+++ b/docs/hu/seminar/ef/index.md
@@ -355,7 +355,7 @@ A `DbContext` nem csak lekérdezéshez használható, hanem rajta keresztül bes
         // 3.2
         Console.WriteLine("\t3.2:");
         var expensiveToysCategory = db.Categories
-            .Where(c => c.Name == "Expensive Toys")
+            .Where(c => c.Name == "Expensive toys")
             .SingleOrDefault();
 
         if (expensiveToysCategory == null)


### PR DESCRIPTION
A docs/hu/seminar/ef/index.md fájlban lévő 3.2-es feladatban először "Expensive Toy"-ra szűrünk, viszont ezután "Expensive toy"-ként hozunk létre táblát és arra is szűrünk, ami problémát okozhat, ha az adatbázis case sensitive-re van beállítva.