### PR TITLE
[EF házi] dotnet test -v n nem listázza az éppen futtatott teszteket

### DIFF
--- a/docs/en/homework/ef/index.md
+++ b/docs/en/homework/ef/index.md
@@ -66,7 +66,9 @@ There are unit tests available in the solution. The test codes are commented out
 
     If you are using `dotnet cli` to run the tests, make sure to display the test names too. Use the `-l "console;verbosity=normal"` command line argument to set detailed logging. Something like this should work: 
 
-    `dotnet test -l "console;verbosity=normal"`
+    ```cmd
+    dotnet test -l "console;verbosity=normal"
+    ```
 
     The image does not need to show the exact same source code that you submit; there can be some minor changes here and there. That is, if the tests run successfully and you create the screenshot, then later you make some **minor** change to the source, there is no need for you to update the screenshot.
 

--- a/docs/hu/homework/ef/index.md
+++ b/docs/hu/homework/ef/index.md
@@ -66,7 +66,9 @@ A teszteléshez találsz unit teszteket a solution-ben. A tesztek kódja ki van 
 
     Ha `dotnet test`-et használsz a teszt futtatásához, a képernyőképen látszódjon az összes teszt neve. Ehhez használd a `-l "console;verbosity=normal"` argumentumot a megtalált tesztek listázásához és futtatásához, valahogy így:
 
-    `dotnet test -l "console;verbosity=normal"`
+    ```
+    dotnet test -l "console;verbosity=normal"
+    ```
 
     A képernyőképen levő forráskód tekintetében nem szükséges, hogy a végső megoldásban szereplő kód betűről betűre megegyezzen a képen és a feltöltött változatban. Tehát a tesztek sikeres lefutása után elkészített képernyőképet nem szükséges frissíteni, ha a forráskódban **kisebb** változtatást eszközölsz.
 


### PR DESCRIPTION
Az EF házi készítése közben azt tapasztaltam, hogy a rendszeremen a `dotnet test -v n` parancs nem a tárgy által elvárt kimenetet adja. Ez a PR ezt az apróságot próbálná meg orvosolni.

## Képernyőkép az eredeti problémáról:

<img width="735" height="146" alt="kép" src="https://github.com/user-attachments/assets/b49d7624-da9c-409d-b2a4-898f3e327153" />

## Reprodukálási lépések:

 - Az első feladat megoldása után futtasd a teszteket dotnet cli-ből a képen látható módon.

## Egyéb dolgok amiket próbáltam:

 - Normálnál beszédesebb módban futtatni a teszteket; így sem listázta ki
 
 ## Javítás:

- A `-t` argumentum kiadásával a program listázza ugyan a teszteket, viszont cserébe nem futtatja. Ennek egy orvoslása, ha kiadjuk először `-t`-vel, majd nélküle a parancsot, például így: `dotnet test -t && dotnet test` Ez már valamivel elfogadhatóbb kimenetet generál:

<img width="829" height="322" alt="kép" src="https://github.com/user-attachments/assets/731b1055-79ae-45cf-865f-976adc33c726" />

## Releváns infók a rendszeremről:
 - EndeavourOS linux, legújabb dotnettel 